### PR TITLE
Add semi-colon

### DIFF
--- a/apps/m0_lowload/src/main.c
+++ b/apps/m0_lowload/src/main.c
@@ -74,7 +74,7 @@ void UART2_IRQHandler(int irq, void *arg)
 #ifdef CONFIG_LL_IRQFWD_USB
 void USB_IRQHandler(int irq, void *arg)
 {
-    LOG_D("Got USB IRQ\r\n")
+  LOG_D("Got USB IRQ\r\n");
     Send_IPC_IRQ(BLFB_IPC_DEVICE_USB);
 }
 #endif


### PR DESCRIPTION
Just noticed a simple typo as I'm trying to bring up the EHCI usb.